### PR TITLE
Fix for LDAP user autorization. Rename to correct entity class.

### DIFF
--- a/src/FOM/UserBundle/Form/DataTransformer/ACEDataTransformer.php
+++ b/src/FOM/UserBundle/Form/DataTransformer/ACEDataTransformer.php
@@ -82,7 +82,7 @@ class ACEDataTransformer implements DataTransformerInterface
                 $class = $sidParts[2];
             } else {
                 if($this->isLdapUser($sidParts[1])) {
-                  $class = 'FOM\UserBundle\Entity\LdapUser';
+                  $class = 'Mapbender\LdapIntegrationBundle\Entity\LdapUser';
                 } else {
                   $class = 'FOM\UserBundle\Entity\User';
                 }


### PR DESCRIPTION
Fix for 3.0.5. LDAP user autorization didn't work because the wrong entity class was defined.

In future we will use the ldapintegration bundle as official module for MB3.