### PR TITLE
Fix delete button position. Add margins between form rows

### DIFF
--- a/src/FOM/CoreBundle/Resources/views/Form/fields.html.twig
+++ b/src/FOM/CoreBundle/Resources/views/Form/fields.html.twig
@@ -45,12 +45,17 @@
       {% if form.vars.prototype is defined  and form.vars.allow_add is defined %}
       <a href="#add" class="collectionAdd iconAdd iconSmall"></a>
       {% endif %}
+      {% if 'allow_delete' in form.parent.vars | keys and form.parent.vars['allow_delete'] %}
+        <a href="#delete" class="collectionRemove iconSmall iconRemove"></a>
+      {% endif %}
+
       {% if form.parent is empty %}
       {{ form_errors(form) }}
       {% endif %}
       {{ block('form_rows') }}
       {{ form_rest(form) }}
     </div>
+
   {% endspaceless %}
 {% endblock form_widget_compound %}
 
@@ -352,9 +357,7 @@
     <div {% if 'collection' in form.parent.vars['block_prefixes'] %}class="collectionItem"{% endif %}>
       {{ form_label(form) }}
       {{ form_widget(form) }}
-      {% if 'allow_delete' in form.parent.vars | keys and form.parent.vars['allow_delete'] %}
-      <a href="#delete" class="collectionRemove iconSmall iconRemove"></a>
-      {% endif %}
+
     </div>
   {% endspaceless %}
 {% endblock form_row %}
@@ -486,6 +489,7 @@
   {% spaceless %}
     {% for child in form %}
       {{ form_row(child) }}
+     <div class="clearContainer"></div>
     {% endfor %}
   {% endspaceless %}
 {% endblock form_rows %}


### PR DESCRIPTION
Delete button appears now on the top edge instead of being below the widget area.
Every form row is now visually divided.