### PR TITLE
Fix "defined and not falsy" check on action display

### DIFF
--- a/src/FOM/ManagerBundle/Resources/views/Manager/actions.html.twig
+++ b/src/FOM/ManagerBundle/Resources/views/Manager/actions.html.twig
@@ -1,6 +1,6 @@
 {% if actions is defined %}
     {% for k,v in actions %}
-    {% if v.display is not defined or v.display != false %}
+    {% if v.display is defined and v.display %}
     {% set attr %}
     {% if v.attr is defined %}{% for k,v in v.attr %} {{k}}="{{v}}"{% endfor %}{% endif %}
     {% endset %}


### PR DESCRIPTION
Repair the twig if condition that is supposed to check if the action is displayable.
This resolves MB 713: https://github.com/mapbender/mapbender/issues/713
