### PR TITLE
Change constructor definition to more unspecific AclProvider to fix b…

### DIFF
--- a/src/FOM/UserBundle/Component/AclManager.php
+++ b/src/FOM/UserBundle/Component/AclManager.php
@@ -3,7 +3,7 @@
 namespace FOM\UserBundle\Component;
 
 use FOM\UserBundle\Entity\AclEntry;
-use Symfony\Component\Security\Acl\Dbal\MutableAclProvider;
+use Symfony\Component\Security\Acl\Model\AclProviderInterface;
 use Symfony\Component\Security\Acl\Domain\Acl;
 use Symfony\Component\Security\Acl\Domain\Entry;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
@@ -32,7 +32,7 @@ use Symfony\Component\Security\Acl\Model\AclInterface;
  */
 class AclManager
 {
-    /** @var MutableAclProvider  */
+    /** @var AclProviderInterface  */
     protected $aclProvider;
 
     /**
@@ -40,7 +40,7 @@ class AclManager
      *
      * @param MutableAclProvider $aclProvider
      */
-    public function __construct(MutableAclProvider $aclProvider)
+    public function __construct(AclProviderInterface $aclProvider)
     {
         $this->aclProvider = $aclProvider;
     }

--- a/src/FOM/UserBundle/Component/AclManager.php
+++ b/src/FOM/UserBundle/Component/AclManager.php
@@ -3,7 +3,7 @@
 namespace FOM\UserBundle\Component;
 
 use FOM\UserBundle\Entity\AclEntry;
-use Symfony\Component\Security\Acl\Model\AclProviderInterface;
+use Symfony\Component\Security\Acl\Model\MutableAclProviderInterface;
 use Symfony\Component\Security\Acl\Domain\Acl;
 use Symfony\Component\Security\Acl\Domain\Entry;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
@@ -32,15 +32,15 @@ use Symfony\Component\Security\Acl\Model\AclInterface;
  */
 class AclManager
 {
-    /** @var AclProviderInterface  */
+    /** @var MutableAclProviderInterface */
     protected $aclProvider;
 
     /**
      * AclManager constructor.
      *
-     * @param MutableAclProvider $aclProvider
+     * @param MutableAclProviderInterface $aclProvider
      */
-    public function __construct(AclProviderInterface $aclProvider)
+    public function __construct(MutableAclProviderInterface $aclProvider)
     {
         $this->aclProvider = $aclProvider;
     }


### PR DESCRIPTION
…roken Symfony/AclManager.php. See https://github.com/mapbender/fom/pull/39 for v3.0.6

Change constructor definition to more unspecific AclProvider to fix broken Symfony/AclManager.php

See: https://github.com/mapbender/fom/pull/39

I take the code from @LazerTiberius to include it also in FOM 3.0.5.