### PR TITLE
fix bug in browser Safari for dropdown list

### DIFF
--- a/src/FOM/CoreBundle/Resources/public/js/widgets/dropdown.js
+++ b/src/FOM/CoreBundle/Resources/public/js/widgets/dropdown.js
@@ -30,8 +30,7 @@ $(function () {
                 var me2 = $(this);
                 var opt = me2.attr("class").replace("item", "opt");
                 me.find(".dropdownValue").text(me2.text());
-                opts.find("[selected=selected]").removeAttr("selected");
-                var val = opts.find("." + opt).attr("selected", "selected").val();
+                var val = opts.find("." + opt).prop("selected", true).val();
                 opts.val(val).trigger('change');
             })
         }


### PR DESCRIPTION
Ticket in Easyredmine https://wheregroup.easyredmine.com/issues/1883
jQuery dropdown selected=selected funtioniert in Safari nicht
Hier eine Erlärung: https://stackoverflow.com/questions/19003238/jquery-dropdown-selected-selected-in-safari-does-not-work