### PR TITLE
Implement __toString-Method for FOM/User

### DIFF
--- a/src/FOM/UserBundle/Entity/User.php
+++ b/src/FOM/UserBundle/Entity/User.php
@@ -465,4 +465,9 @@ class User implements AdvancedUserInterface
     {
         return true;
     }
+    
+    public function __toString()
+    {
+        return $this->getUsername();
+    }
 }


### PR DESCRIPTION
Some parts of the Symofony User machinery are not strict on the type of some User-Objects. If we try to implement other login mechanics instead of form_login based on the FOM/User it can happen that we get a User-Object in the loadUserByUsername-Method if a Symfomy UserProvider. This method expects a String as an argument, therefore we need this __toString-Methods. Otherwise we get a cast-Execption.